### PR TITLE
Allow more than one option to be a colour picker

### DIFF
--- a/Views/js/designer.js
+++ b/Views/js/designer.js
@@ -482,7 +482,7 @@ var designer = {
                 if ($(this).attr("id")=="html"){
                     $("#"+designer.selected_box).html($(this).val());
                 }
-                else if ($(this).attr("id")=="colour"){
+                else if ($(this).attr("id").substring(0,6)=="colour"){
                     // Since colour values are generally prefixed with "#", and "#" isn't valid in URLs, we strip out the "#".
                     // It will be replaced by the value-checking in the actual plot function, so this won't cause issues.
                     var colour = $(this).val();


### PR DESCRIPTION
Instead of checking on full name (id=="colour"), it now checks on a prefix (id starts with "colour"). Needed for visualizations that may define more than one colour (for example stacked).

Without this change, PR #444 (colour configuration in Stacked visualization) doesn't work inside dashboards.