### PR TITLE
Add key bindings to move things around the dashboard editor

### DIFF
--- a/Views/js/designer.js
+++ b/Views/js/designer.js
@@ -511,6 +511,8 @@ var designer = {
 
                 designer.draw();
                 designer.modified();
+
+                e.preventDefault();
             }
         });
 

--- a/Views/js/designer.js
+++ b/Views/js/designer.js
@@ -483,6 +483,9 @@ var designer = {
             if (keyCode >= 37 && keyCode <= 40) {
                 if (!designer.selected_box) return;
 
+                var targetTagName = e.target.tagName.toLowerCase();
+                if (targetTagName === 'input' || targetTagName === 'textarea') return;
+
                 var left_shift = 0;
                 var top_shift = 0;
 

--- a/Views/js/designer.js
+++ b/Views/js/designer.js
@@ -476,6 +476,44 @@ var designer = {
             }
         });
 
+        // Key events
+        window.addEventListener('keydown', function(e) {
+            var keyCode = e.keyCode;
+
+            if (keyCode >= 37 && keyCode <= 40) {
+                if (!designer.selected_box) return;
+
+                var left_shift = 0;
+                var top_shift = 0;
+
+                switch(keyCode) {
+                    case 37: // Left
+                      left_shift = -1;
+                      break;
+                    case 38: // Up
+                      top_shift = -1;
+                      break;
+                    case 39: // Right
+                      left_shift = 1;
+                      break;
+                    case 40: // Down
+                      top_shift = 1;
+                      break;
+                    default:
+                      // Unhandled
+                      break;
+                }
+
+                var snap_amount = Math.max(designer.grid_size, 1);
+
+                designer.boxlist[designer.selected_box]['left'] = designer.boxlist[designer.selected_box]['left'] + (left_shift * snap_amount);
+                designer.boxlist[designer.selected_box]['top'] = designer.boxlist[designer.selected_box]['top'] + (top_shift * snap_amount);
+
+                designer.draw();
+                designer.modified();
+            }
+        });
+
         // On save click
         $("#options-save").click(function(){
             $(".options").each(function() {

--- a/Views/js/designer.js
+++ b/Views/js/designer.js
@@ -477,7 +477,7 @@ var designer = {
         });
 
         // Key events
-        window.addEventListener('keydown', function(e) {
+        $(window).keydown(function(e) {
             var keyCode = e.keyCode;
 
             if (keyCode >= 37 && keyCode <= 40) {


### PR DESCRIPTION
This adds key bindings when on the dashboard editor so that you can move items around with the arrow keys. Items move by 1 grid size unit in whichever direction of arrow you press.