### PR TITLE
Don't do the delete if you're inside an input or textarea

### DIFF
--- a/Views/js/designer.js
+++ b/Views/js/designer.js
@@ -435,6 +435,9 @@ var designer = {
     },
     
     'handle_delete_key_event': function(e){
+        var targetTagName = e.target.tagName.toLowerCase();
+        if (targetTagName === 'input' || targetTagName === 'textarea') return false;
+
         if (designer.selected_box) {
             designer.delete_selected_boxes();
             return true;


### PR DESCRIPTION
@Paul-Reed - sorry about this... I just noticed that with my delete key binding, you can end up deleting the selected element while you're configuring it, if you press backspace / delete while in a text box. This commit fixes it.