### PR TITLE
Add apikey to list query, so that you can view dashboards with the readkey

### DIFF
--- a/Views/js/render.js
+++ b/Views/js/render.js
@@ -76,6 +76,7 @@ function gpu_fast_update() {
 // update function
 function update(first_time){
   var query = path + "feed/list.json?userid="+userid;
+  if (apikey) query += "&apikey="+apikey;
   $.ajax(
   {
     type: "GET",


### PR DESCRIPTION
This fixes it so that with the read key passed as the `apikey` parameter in the URL query, you can see a dashboard. Without this fix, widgets are blank because the `list` query doesn't pass the API key, so you don't get any results back.