### PR TITLE
Make undo and redo set modified state correctly

### DIFF
--- a/Views/js/designer.js
+++ b/Views/js/designer.js
@@ -113,6 +113,7 @@ var designer = {
         designer.selected_box = 0;
         designer.scan();
         designer.draw();
+        designer.modified();
         designer.check_undo_state();
     },
 
@@ -129,6 +130,7 @@ var designer = {
         designer.selected_box = 0;
         designer.scan();
         designer.draw();
+        designer.modified();
         designer.check_undo_state();
     },
 


### PR DESCRIPTION
We had an issue where if you made some changes, then saved, then did an undo or redo, you couldn't save until you made another change. This was because undo and redo weren't setting the modified state. This fixes that.

Fixes #34.