### PR TITLE
Toolbox js reworked

### DIFF
--- a/Views/dashboard_edit_view.php
+++ b/Views/dashboard_edit_view.php
@@ -20,7 +20,6 @@ if (!$dashboard['height']) $dashboard['height'] = 400;
     <script type="text/javascript" src="<?php echo $path; ?>Modules/dashboard/dashboard.js"></script>
     <script type="text/javascript" src="<?php echo $path; ?>Modules/dashboard/Views/js/widgetlist.js"></script>
     <script type="text/javascript" src="<?php echo $path; ?>Modules/dashboard/Views/js/render.js"></script>
-	<script type="text/javascript" src="<?php echo $path; ?>/modules/dashboard/byrei-dyndiv_1.0rc1.js"></script>
     <script type="text/javascript" src="<?php echo $path; ?>Modules/feed/feed.js"></script>
 
     <?php require_once "Modules/dashboard/Views/loadwidgets.php"; ?>

--- a/Views/dashboard_edit_view.php
+++ b/Views/dashboard_edit_view.php
@@ -20,7 +20,7 @@ if (!$dashboard['height']) $dashboard['height'] = 400;
     <script type="text/javascript" src="<?php echo $path; ?>Modules/dashboard/dashboard.js"></script>
     <script type="text/javascript" src="<?php echo $path; ?>Modules/dashboard/Views/js/widgetlist.js"></script>
     <script type="text/javascript" src="<?php echo $path; ?>Modules/dashboard/Views/js/render.js"></script>
-
+	<script type="text/javascript" src="<?php echo $path; ?>/modules/dashboard/byrei-dyndiv_1.0rc1.js"></script>
     <script type="text/javascript" src="<?php echo $path; ?>Modules/feed/feed.js"></script>
 
     <?php require_once "Modules/dashboard/Views/loadwidgets.php"; ?>
@@ -39,25 +39,59 @@ if (!$dashboard['height']) $dashboard['height'] = 400;
     </div>
 </div>
 
-<div data-draggable="true" class="toolbox" style="cursor:move; background-color:#ddd; padding:10px; position:fixed;z-index:1; border-radius: 15px 15px 15px 15px; width: 130px; height: 330px; top:110px; right: 50px;">
-    <span id="widget-buttons"></span>
-    <span id="undo-buttons">
-        <button id="undo-button" class="btn" style="float:left; width:65px"><i class="icon-backward"></i> <?php echo _('Undo'); ?></button>
-        <button id="redo-button" class="btn" style="float:left; width:65px"><i class="icon-forward"></i> <?php echo _('Redo'); ?></button>
-    </span>
-    <span id="when-selected">
-        <button id="options-button" class="btn" style="float:left; width:130px" data-toggle="modal" data-target="#widget_options"><i class="icon-wrench"></i> <?php echo _('Configure'); ?></button>
-        <button id="move-forward-button" class="btn" style="float:left; width:65px"><i class="icon-arrow-up"></i> <?php echo _('Forw.'); ?></button>
-        <button id="move-backward-button" class="btn" style="float:left; width:65px"><i class="icon-arrow-down"></i> <?php echo _('Backw.'); ?></button>
-        <button id="delete-button" class="btn btn-danger" style="float:left; width:130px"><i class="icon-trash"></i> <?php echo _('Delete'); ?></button>
-    </span>
-    <span><button id="save-dashboard" class="btn btn-success" style="float:left; width:130px; bottom: 5px"><?php echo _('Not modified'); ?></button></span>
+<div id="toolbox" class="toolbox" style="background-color:#ddd; padding:10px; position:fixed;z-index:1; border-radius: 15px 15px 15px 15px; border-style:groove; width: 130px; height: auto; top:110px; right: 50px;">
+	<span id="dashboard-config-buttons">
+	<button id="dashboard-config-button" style="float:left"  class='btn' style="float:right" href='#dashConfigModal' role='button' data-toggle='modal'><span class='icon-wrench' title= <?php echo ("Configure dashboard"); ?>></span></button>
+	<a class='btn' style="float:right" href=' <?php echo ('/dashboard/view?id='); ?><?php echo $dashboard['id']; ?>' ><i class='icon-eye-open' title=<?php echo ("View Mode"); ?>></i></a>
+	</span>
+	<span id="widget-buttons"></span>
+	<span id="undo-buttons">
+		<button id="undo-button" class="btn" style="float:left; width:65px"><span class="icon-arrow-left"></span><?php echo _('Undo'); ?></button>
+		<button id="redo-button" class="btn" style="float:left; width:65px"><i class="icon-arrow-right"></i> <?php echo _('Redo'); ?></button>
+	</span>
+	<span id="when-selected">
+		<button id="options-button" class="btn" style="float:left; width:130px" data-toggle="modal" data-target="#widget_options"><i class="icon-wrench"></i> <?php echo _('Configure'); ?></button>
+		<button id="move-forward-button" class="btn" style="float:left; width:65px"><i class="icon-arrow-up"></i> <?php echo _('Forw.'); ?></button>
+		<button id="move-backward-button" class="btn" style="float:left; width:65px"><i class="icon-arrow-down"></i> <?php echo _('Backw.'); ?></button>
+		<button id="delete-button" class="btn btn-danger" style="float:left; width:130px"><i class="icon-trash"></i> <?php echo _('Delete'); ?></button>
+	</span>
+	<span><button id="save-dashboard" class="btn btn-success" style="float:left; width:130px; bottom: 5px"><?php echo _('Not modified'); ?></button></span>
 </div>
+
 
 <div id="page-container" style="height:<?php echo $dashboard['height']; ?>px; background-color:#<?php echo $dashboard['backgroundcolor']; ?>; position:relative;">
     <div id="page"><?php echo $dashboard['content']; ?></div>
     <canvas id="can" width="940px" height="<?php echo $dashboard['height']; ?>px" style="position:absolute; top:0px; left:0px; margin:0; padding:0;"></canvas>
 </div>
+
+<script type="application/javascript">
+window.onload = addListeners();
+var x_pos = 0,
+	y_pos = 0;
+
+function addListeners() {
+  document.getElementById('toolbox').addEventListener('mousedown', mouseDown, false);
+  window.addEventListener('mouseup', mouseUp, false);
+}
+
+function mouseUp() {
+  window.removeEventListener('mousemove', divMove, true);
+}
+
+function mouseDown(e) {
+  var div = document.getElementById('toolbox');
+  x_pos = e.clientX - div.offsetLeft;
+  y_pos = e.clientY - div.offsetTop;
+  window.addEventListener('mousemove', divMove, true);
+}
+
+function divMove(e) {
+  var div = document.getElementById('toolbox');
+  div.style.position = 'absolute';
+  div.style.top = (e.clientY - y_pos) + 'px';
+  div.style.left = (e.clientX - x_pos) + 'px';
+}
+</script>
 
 <script type="text/javascript" src="<?php echo $path; ?>Modules/dashboard/Views/js/designer.js"></script>
 <script type="application/javascript">

--- a/Views/dashboard_edit_view.php
+++ b/Views/dashboard_edit_view.php
@@ -41,7 +41,7 @@ if (!$dashboard['height']) $dashboard['height'] = 400;
 <div id="toolbox" class="toolbox" style="background-color:#ddd; padding:10px; position:fixed;z-index:1; border-radius: 15px 15px 15px 15px; border-style:groove; width: 130px; height: auto; top:110px; right: 50px;">
 	<span id="dashboard-config-buttons">
 	<button id="dashboard-config-button" style="float:left"  class='btn' style="float:right" href='#dashConfigModal' role='button' data-toggle='modal'><span class='icon-wrench' title= <?php echo ("Configure dashboard"); ?>></span></button>
-	<a class='btn' style="float:right" href=' <?php echo ('/dashboard/view?id='); ?><?php echo $dashboard['id']; ?>' ><i class='icon-eye-open' title=<?php echo ("View Mode"); ?>></i></a>
+	<a class='btn' style="float:right" href=' <?php echo ($path.'/dashboard/view?id='); ?><?php echo $dashboard['id']; ?>' ><i class='icon-eye-open' title=<?php echo ("View Mode"); ?>></i></a>
 	</span>
 	<span id="widget-buttons"></span>
 	<span id="undo-buttons">

--- a/Views/dashboard_menu.php
+++ b/Views/dashboard_menu.php
@@ -17,10 +17,6 @@
         $result .= "<a class='btn btn-mini' href='" . $path . "dashboard/edit?id=" . $id . "'><span class='icon-edit' title='" . _("Draw Editor") . "'></span></a>";
     }
 
-    if ($type=="edit" && isset($id)) {
-        $result .= "<a class='btn btn-mini' href='#dashConfigModal' role='button' data-toggle='modal'><span class='icon-wrench' title='" . _("Configure dashboard") . "'></span></a>";
-        $result .= "<a class='btn btn-mini' href='" . $path . "dashboard/view?id=" . $id . "'><span class='icon-eye-open' title='" . _("View mode") . "'></span></a>";
-    }
 
     //CHAVEIRO: Removed, dashboard list is accessible via setup menu now
     //if ($type!="list") {

--- a/Views/js/designer.js
+++ b/Views/js/designer.js
@@ -473,7 +473,7 @@ var designer = {
 
         for (z in select){
             widget_html += "<div class='btn-group' style='white-space:normal; width:130px'><button class='btn dropdown-toggle widgetmenu' data-toggle='dropdown' style='width:100%'>"+z+"&nbsp<span class='caret'></span></button>";
-            widget_html += "<ul class='dropdown-menu' style='top:30px' name='d'>"+select[z]+"</ul>";
+            widget_html += "<ul class='dropdown-menu scrollable-menu' style='top:30px' name='d'>"+select[z]+"</ul>";
         }
         $("#widget-buttons").html(widget_html);
 

--- a/Views/js/designer.js
+++ b/Views/js/designer.js
@@ -15,51 +15,6 @@
 
 var selected_edges = {none : 0, left : 1, right : 2, top : 3, bottom : 4, center : 5};
 
-$(document).ready(function() {
-		    
-		    var $body = $('body');
-		    var $target = null;
-		    var isDraggEnabled = false;
-
-		    $body.on("mousedown", "div", function(e) {
-		       
-		    	$this = $(this);
-		       	isDraggEnabled = $this.data("draggable");
-
-		       	if (isDraggEnabled) {
-		       		if(e.offsetX==undefined){
-						x = e.pageX-$(this).offset().left;
-						y = e.pageY-$(this).offset().top;
-					}else{
-						x = e.offsetX;
-						y = e.offsetY;
-					};
-
-					$this.addClass('draggable');
-		        	$body.addClass('noselect');
-		        	$target = $(e.target);
-		       	};
-   
-		    });
-		    
-		     $body.on("mouseup", function(e) {
-		        $target = null;
-		        $body.find(".draggable").removeClass('draggable');
-		        $body.removeClass('noselect');
-		    });
-		    
-		     $body.on("mousemove", function(e) {
-	            if ($target) {
-	                $target.offset({
-	                    top: e.pageY  - y,
-	                    left: e.pageX - x
-	                });
-	            };     
-		     });
-
-		});
-
-
 var designer = {
 
     'grid_size':20,


### PR DESCRIPTION
Found issue with elements within the div draggable too. Reworked js code and now only the palette itself is draggable.

- added submenu icons "daschboard config and preview into the palette.
- removed the icons from the submenu and ensured that the submenu is not visible anymore in edit mode
- styled the buttons to be the same height as the others are (still need to figure out new icons or icon name combination for later or adding additional small icons there like instead big buttons for undo/redo, backw/forw.
- added auto grow to the div so the palette will get bigger as soon as a element has been selected.
- added border to the palette to make it more visible in case of grey dashboard elements