### PR TITLE
Changed palette position & transparency in view mode

### DIFF
--- a/Views/dashboard_edit_view.php
+++ b/Views/dashboard_edit_view.php
@@ -38,7 +38,7 @@ if (!$dashboard['height']) $dashboard['height'] = 400;
     </div>
 </div>
 
-<div id="toolbox" class="toolbox" style="background-color:#ddd; padding:10px; position:fixed;z-index:1; border-radius: 15px 15px 15px 15px; border-style:groove; width: 130px; height: auto; top:110px; right: 50px;">
+<div id="toolbox" class="toolbox" style="background-color:#ddd; padding:5px; position:fixed;z-index:1; border-radius: 10px 10px 10px 10px; border-style:groove; width: 130px; height: auto; top:55px; right: 10px;">
 	<span id="dashboard-config-buttons">
 	<button id="dashboard-config-button" style="float:left"  class='btn' style="float:right" href='#dashConfigModal' role='button' data-toggle='modal'><span class='icon-wrench' title= <?php echo ("Configure dashboard"); ?>></span></button>
 	<a class='btn' style="float:right" href=' <?php echo ($path.'/dashboard/view?id='); ?><?php echo $dashboard['id']; ?>' ><i class='icon-eye-open' title=<?php echo ("View Mode"); ?>></i></a>

--- a/Views/dashboard_view.php
+++ b/Views/dashboard_view.php
@@ -20,9 +20,9 @@ global $session,$path;
 
   <?php require_once "Modules/dashboard/Views/loadwidgets.php"; ?>
 
-  <div id="editicon" style="background-color:#ddd; padding:5px; opacity:0.3; position:fixed;z-index:1; border-radius: 15px 15px 15px 15px; border-style:groove; width: 130px; height: auto; top:60px; right: 20px;">
+  <div id="editicon" style="background-color:transparent; padding:5px; position:fixed;z-index:1; width: 130px; height: auto; top:63px; right: 27px;">
 	<span id="dashboard-config-button">
-	<a id="editbutton" style="float:left; text-align:center" class='btn' href='<?php echo ($path.'dashboard/edit?id='); ?><?php echo $dashboard['id']; ?>'><i class='icon-wrench' ></i> <?php echo _('Edit Dashboard'); ?></a>
+	<a id="editbutton" style="float:right; text-align:center" class='btn-link' href='<?php echo ($path.'dashboard/edit?id='); ?><?php echo $dashboard['id']; ?>'><i class='icon-cog' ></i> <?php ?></a>
 	</span>
 	</div>
 


### PR DESCRIPTION
Aligned the view and edit palette positions so the edit/view toggle
button position doesn't move when toggling.
Made the pallete/button transparent  in view mode.
Moved both palettes tighter into the top RH corner to keep the "edit"
icon as far out of the main screen area as possible durnig normal
viewing.