### PR TITLE
Fixing moving Palette outside of upper and left DIV limits

### DIFF
--- a/Views/dashboard_edit_view.php
+++ b/Views/dashboard_edit_view.php
@@ -100,9 +100,13 @@ function pauseEvent(e){
 }
 
 function toolboxMove(e) {
-  var left = e.clientX - startx;
-  var top = e.clientY - starty;
-  $('#toolbox').css({position: 'absolute', left: left+'px', top: top+'px'});
+  var posx = e.clientX - startx;
+  var posy = e.clientY - starty;
+  if (posx < 0 ) posx = 0;
+  if (posy < 50 ) posy = 50;
+	
+  $('#toolbox').css({position: 'absolute', left: posx+'px', top: posy+'px'});
+  console.log("posx:" + posx + "posy:" + posy);
 }
 </script>
 


### PR DESCRIPTION
Added fixed values for stopping the palette from moving of screen on the left and top.
Moving it to the right and down still works and will create a scrollbar. The palette is therefore always reachable.