### PR TITLE
Change precision rules to maintain digit count

### DIFF
--- a/widget/bar/bar_render.js
+++ b/widget/bar/bar_render.js
@@ -257,11 +257,11 @@ if (colour_label.indexOf("#") == -1)			// Fix missing "#" on colour if needed
 		}
 	}
 
-	if (raw_value>100)
+	if (raw_value>=100)
 	{
 		raw_value = raw_value.toFixed(0);
 	}
-	else if (raw_value>10)
+	else if (raw_value>=10)
 	{
 		raw_value = raw_value.toFixed(1);
 	}


### PR DESCRIPTION
For example, to correct;
9.00 = 3 digits
10.00 = 4 digits
11.0 = 3 digits