### PR TITLE
Tooltip improvement

### DIFF
--- a/widget/bar/bar_render.js
+++ b/widget/bar/bar_render.js
@@ -343,7 +343,7 @@ function draw_bar(context,
 
         h=hotspots[0];
         if(dx >= h.xspot && dx < h.xspot + h.wspot && dy >= h.yspot && dy < h.yspot + h.hspot){
-        tt1.style.cssText = "position:fixed;background-color:#DDDDDD;opacity:0.8;border: 1px solid rgb(255, 221, 221);pointer-events:none;font-weight: bold;";
+        tt1.style.cssText = "position:fixed;background-color:#DDDDDD;opacity:0.8;border: 1px solid rgb(255, 221, 221);pointer-events:none;font-weight: bold; z-index: 100;";
         tt1.style.left = e.clientX + 15 + "px";
         tt1.style.top =  e.clientY + 15+ "px";
         tt1.style.visibility ="visible";
@@ -355,7 +355,7 @@ function draw_bar(context,
 
         h=hotspots[1];
         if(dx >= h.xspot && dx < h.xspot + h.wspot && dy >= h.yspot && dy < h.yspot + h.hspot){
-        tt2.style.cssText = "position:fixed;background-color:#DDDDDD;opacity:0.8;border: 1px solid rgb(255, 221, 221);pointer-events:none;font-weight: bold;";
+        tt2.style.cssText = "position:fixed;background-color:#DDDDDD;opacity:0.8;border: 1px solid rgb(255, 221, 221);pointer-events:none;font-weight: bold; z-index: 100;";
         tt2.style.left = e.clientX + 15 + "px";
         tt2.style.top =  e.clientY + 15+ "px";
         tt2.style.visibility ="visible";

--- a/widget/dial/dial_render.js
+++ b/widget/dial/dial_render.js
@@ -482,7 +482,7 @@ function draw_gauge(ctx,canvasid,x,y,width,height,position,maxvalue,units,decima
        dx=mouseX-h.xspot;
        dy=mouseY-h.yspot;
        if(dx*dx+dy*dy<h.radius*h.radius){
-        tt1.style.cssText = "position:fixed;background-color:#DDDDDD;opacity:0.8;border: 1px solid rgb(255, 221, 221);pointer-events:none;font-weight: bold;";
+        tt1.style.cssText = "position:fixed;background-color:#DDDDDD;opacity:0.8;border: 1px solid rgb(255, 221, 221);pointer-events:none;font-weight: bold; z-index: 100;";
         tt1.style.left = e.clientX + 15 + "px";
         tt1.style.top =  e.clientY + 15+ "px";
         tt1.style.visibility ="visible";
@@ -496,7 +496,7 @@ function draw_gauge(ctx,canvasid,x,y,width,height,position,maxvalue,units,decima
        dx=mouseX-h.xspot;
        dy=mouseY-h.yspot;
        if(dx*dx+dy*dy<h.radius*h.radius){
-       tt2.style.cssText = "position:fixed;background-color:#DDDDDD;opacity:0.8;border: 1px solid rgb(255, 221, 221);pointer-events:none;font-weight: bold;";
+       tt2.style.cssText = "position:fixed;background-color:#DDDDDD;opacity:0.8;border: 1px solid rgb(255, 221, 221);pointer-events:none;font-weight: bold; z-index: 100;";
        tt2.style.left = e.clientX + 15 + "px";
        tt2.style.top =  e.clientY + 15+ "px";
        tt2.style.visibility ="visible";

--- a/widget/thermometer/thermometer_render.js
+++ b/widget/thermometer/thermometer_render.js
@@ -395,7 +395,7 @@ function draw_thermometer(context,
 
         h=hotspots[0];
         if(dx >= h.xspot && dx < h.xspot + h.wspot && dy >= h.yspot && dy < h.yspot + h.hspot){
-        tt1.style.cssText = "position:fixed;background-color:#DDDDDD;opacity:0.8;border: 1px solid rgb(255, 221, 221);pointer-events:none;font-weight: bold;";
+        tt1.style.cssText = "position:fixed;background-color:#DDDDDD;opacity:0.8;border: 1px solid rgb(255, 221, 221);pointer-events:none;font-weight: bold; z-index: 100;";
         tt1.style.left = e.clientX + 15 + "px";
         tt1.style.top =  e.clientY + 15+ "px";
         tt1.style.visibility ="visible";
@@ -407,7 +407,7 @@ function draw_thermometer(context,
 
         h=hotspots[1];
         if(dx >= h.xspot && dx < h.xspot + h.wspot && dy >= h.yspot && dy < h.yspot + h.hspot){
-        tt2.style.cssText = "position:fixed;background-color:#DDDDDD;opacity:0.8;border: 1px solid rgb(255, 221, 221);pointer-events:none;font-weight: bold;";
+        tt2.style.cssText = "position:fixed;background-color:#DDDDDD;opacity:0.8;border: 1px solid rgb(255, 221, 221);pointer-events:none;font-weight: bold; z-index: 100;";
         tt2.style.left = e.clientX + 15 + "px";
         tt2.style.top =  e.clientY + 15+ "px";
         tt2.style.visibility ="visible";


### PR DESCRIPTION
Add z-index property in order to be sure that tooltip is visible when the tooltip is outside the area of the associated widget