### PR TITLE
Added timeout in FeedValue, Dial and Bar and new Widget called FeedTime

### DIFF
--- a/widget/bar/bar_render.js
+++ b/widget/bar/bar_render.js
@@ -108,7 +108,7 @@ function bar_widgetlist()
     addOption(widgets["bar"], "minvaluefeed",   "feedid",           _Tr("Min. feed"),       _Tr("The feed for the minimum value"),                                              []);
     addOption(widgets["bar"], "maxvaluefeed",   "feedid",           _Tr("Max. feed"),       _Tr("The feed for the maximum value"),                                              []);
     addOption(widgets["bar"], "colour_minmax",  "colour_picker",    _Tr("Colour"),          _Tr("Colour for min. and max. bars"),                                               []);
-    addOption(widgets["bar"], "timeout",        "value",            _Tr("Timeout"),         _Tr("Timeout without feed update in seconds (0 is never, empty defaults to 60)"),   []);
+    addOption(widgets["bar"], "timeout",        "value",            _Tr("Timeout"),         _Tr("Timeout without feed update in seconds (empty is never)"),   []);
 
 
 

--- a/widget/bar/bar_render.js
+++ b/widget/bar/bar_render.js
@@ -140,7 +140,7 @@ function draw_bar(context,
                   minvaluefeed,
                   maxvaluefeed,
                   colour_minmax,
-                  error_code
+                  errorCode
                   )
 {
     if (!context) {return;}
@@ -412,7 +412,7 @@ function draw_bar(context,
 
     context.fillStyle = colour_label;
     
-    if (error_code == "1")
+    if (errorCode == "1")
     {
       raw_value="TO ";
       units_string="Error";
@@ -475,9 +475,9 @@ function bar_draw()
 {
     $(".bar").each(function(index)
     {
-        var error_timeout = $(this).attr("timeout");
-        if (error_timeout == "" || error_timeout == undefined)            //Timeout parameter is empty
-          error_timeout = 0;
+        var errorTimeout = $(this).attr("timeout");
+        if (errorTimeout == "" || errorTimeout == undefined)            //Timeout parameter is empty
+          errorTimeout = 0;
 
         var feedid = $(this).attr("feedid");
         var minvaluefeed = $(this).attr("minvaluefeed");
@@ -493,13 +493,13 @@ function bar_draw()
         var minval = curve_value(minvaluefeed,dialrate).toFixed(3);
         var maxval = curve_value(maxvaluefeed,dialrate).toFixed(3);
 
-        var error_code = 0;
+        var errorCode = 0;
 
-        if (error_timeout != 0)
+        if (errorTimeout != 0)
         {
-          if (((new Date()).getTime() / 1000 - offsetofTime - (associd[feedid]["time"] * 1)) > error_timeout) 
+          if (((new Date()).getTime() / 1000 - offsetofTime - (associd[feedid]["time"] * 1)) > errorTimeout) 
           {
-            error_code = "1";
+            errorCode = "1";
             val = 0;    
           }
         }
@@ -532,7 +532,7 @@ function bar_draw()
                      minval*scale,
                      maxval*scale,
                      $(this).attr("colour_minmax"),
-                     error_code
+                     errorCode
                      );
         }
     });

--- a/widget/bar/bar_render.js
+++ b/widget/bar/bar_render.js
@@ -108,6 +108,8 @@ function bar_widgetlist()
     addOption(widgets["bar"], "minvaluefeed",   "feedid",           _Tr("Min. feed"),       _Tr("The feed for the minimum value"),                                              []);
     addOption(widgets["bar"], "maxvaluefeed",   "feedid",           _Tr("Max. feed"),       _Tr("The feed for the maximum value"),                                              []);
     addOption(widgets["bar"], "colour_minmax",  "colour_picker",    _Tr("Colour"),          _Tr("Colour for min. and max. bars"),                                               []);
+    addOption(widgets["bar"], "timeout",        "value",            _Tr("Timeout"),         _Tr("Timeout without feed update (0 is never, empty is default"),                   []);
+
 
 
     return widgets;
@@ -137,7 +139,8 @@ function draw_bar(context,
                   displayminmax,
                   minvaluefeed,
                   maxvaluefeed,
-                  colour_minmax
+                  colour_minmax,
+                  error_code
                   )
 {
     if (!context) {return;}
@@ -409,6 +412,12 @@ function draw_bar(context,
 
     context.fillStyle = colour_label;
     
+    if (error_code == "1")
+    {
+      raw_value="TO ";
+      units_string="Error";
+    }
+
     var unitsandval = raw_value+units_string;
     var valsize;
     if (unitsandval.length >4){ valsize = (size / (unitsandval.length+2)) * 5.5;}
@@ -466,6 +475,10 @@ function bar_draw()
 {
     $(".bar").each(function(index)
     {
+        var error_timeout = $(this).attr("timeout");
+        if (error_timeout == "" || error_timeout == undefined)            //Timeout parameter is empty
+          error_timeout = 60;
+
         var feedid = $(this).attr("feedid");
         var minvaluefeed = $(this).attr("minvaluefeed");
         var maxvaluefeed = $(this).attr("maxvaluefeed");
@@ -480,6 +493,16 @@ function bar_draw()
         var minval = curve_value(minvaluefeed,dialrate).toFixed(3);
         var maxval = curve_value(maxvaluefeed,dialrate).toFixed(3);
 
+        var error_code = 0;
+
+        if (error_timeout != 0)
+        {
+          if (((new Date()).getTime() / 1000 - offsetofTime - (associd[feedid]["time"] * 1)) > error_timeout) 
+          {
+            error_code = "1";
+            val = 0;    
+          }
+        }
         // ONLY UPDATE ON CHANGE
         if (val != (associd[feedid]["value"] * 1).toFixed(3) || minval != (associd[minvaluefeed]["value"] * 1).toFixed(3) || maxval != (associd[maxvaluefeed]["value"] * 1).toFixed(3) ||redraw == 1)
         {
@@ -508,7 +531,8 @@ function bar_draw()
                      $(this).attr("displayminmax"),
                      minval*scale,
                      maxval*scale,
-                     $(this).attr("colour_minmax")
+                     $(this).attr("colour_minmax"),
+                     error_code
                      );
         }
     });

--- a/widget/bar/bar_render.js
+++ b/widget/bar/bar_render.js
@@ -477,7 +477,7 @@ function bar_draw()
     {
         var error_timeout = $(this).attr("timeout");
         if (error_timeout == "" || error_timeout == undefined)            //Timeout parameter is empty
-          error_timeout = 60;
+          error_timeout = 0;
 
         var feedid = $(this).attr("feedid");
         var minvaluefeed = $(this).attr("minvaluefeed");

--- a/widget/bar/bar_render.js
+++ b/widget/bar/bar_render.js
@@ -108,7 +108,7 @@ function bar_widgetlist()
     addOption(widgets["bar"], "minvaluefeed",   "feedid",           _Tr("Min. feed"),       _Tr("The feed for the minimum value"),                                              []);
     addOption(widgets["bar"], "maxvaluefeed",   "feedid",           _Tr("Max. feed"),       _Tr("The feed for the maximum value"),                                              []);
     addOption(widgets["bar"], "colour_minmax",  "colour_picker",    _Tr("Colour"),          _Tr("Colour for min. and max. bars"),                                               []);
-    addOption(widgets["bar"], "timeout",        "value",            _Tr("Timeout"),         _Tr("Timeout without feed update (0 is never, empty is default"),                   []);
+    addOption(widgets["bar"], "timeout",        "value",            _Tr("Timeout"),         _Tr("Timeout without feed update in seconds (0 is never, empty defaults to 60)"),   []);
 
 
 

--- a/widget/bar/bar_render.js
+++ b/widget/bar/bar_render.js
@@ -476,7 +476,7 @@ function bar_draw()
     $(".bar").each(function(index)
     {
         var errorTimeout = $(this).attr("timeout");
-        if (errorTimeout == "" || errorTimeout == undefined)            //Timeout parameter is empty
+        if (errorTimeout === "" || errorTimeout === undefined)            //Timeout parameter is empty
           errorTimeout = 0;
 
         var feedid = $(this).attr("feedid");
@@ -495,7 +495,7 @@ function bar_draw()
 
         var errorCode = 0;
 
-        if (errorTimeout != 0)
+        if (errorTimeout !== 0)
         {
           if (((new Date()).getTime() / 1000 - offsetofTime - (associd[feedid]["time"] * 1)) > errorTimeout) 
           {

--- a/widget/bar/bar_widget.php
+++ b/widget/bar/bar_widget.php
@@ -1,0 +1,15 @@
+<?php
+/*
+  All Emoncms code is released under the GNU Affero General Public License.
+  See COPYRIGHT.txt and LICENSE.txt.
+    ---------------------------------------------------------------------
+    Part of the OpenEnergyMonitor project:
+    http://openenergymonitor.org
+    Widget initially created by Aymeric Thibaut
+ */
+ ?>
+<script type="application/javascript">
+  var requestTime = Date.now() /1000;
+  var offsetofTime = 0;
+  offsetofTime = Math.round(requestTime - <?php echo time(); ?>); // Offset in s from local to server time
+</script>

--- a/widget/dial/dial_render.js
+++ b/widget/dial/dial_render.js
@@ -98,7 +98,7 @@ function dial_widgetlist(){
   addOption(widgets["dial"], "displayminmax", "dropbox", _Tr("Min / Max ?"),  _Tr("Display Min. and Max. ?"),                                               displayminmaxDropBoxOptions);
   addOption(widgets["dial"], "minvaluefeed",  "feedid",  _Tr("Min. feed"),    _Tr("The feed for the minimum value"),                                        []);
   addOption(widgets["dial"], "maxvaluefeed",  "feedid",  _Tr("Max. feed"),    _Tr("The feed for the maximum value"),                                        []);
-  addOption(widgets["dial"], "timeout",       "value",   _Tr("Timeout"),       _Tr("Timeout without feed update"),                                           []);
+  addOption(widgets["dial"], "timeout",       "value",   _Tr("Timeout"),       _Tr("Timeout without feed update in seconds (0 is never, empty defaults to 60)"),                                           []);
 
   return widgets;
 }

--- a/widget/dial/dial_render.js
+++ b/widget/dial/dial_render.js
@@ -544,7 +544,7 @@ function dial_draw(){
     
     var error_timeout = $(this).attr("timeout");
         if (error_timeout == "" || error_timeout == undefined)            //Timeout parameter is empty
-          error_timeout = 60;
+          error_timeout = 0;
 
 
     var error_code = "0";

--- a/widget/dial/dial_render.js
+++ b/widget/dial/dial_render.js
@@ -123,7 +123,7 @@ function polar_to_cart(mag, ang, xOff, yOff){
   }
 // X, Y are the center coordinates of the canvas
 function draw_gauge(ctx,canvasid,x,y,width,height,position,maxvalue,units,decimals,type,offset,graduationBool,unitend,displayminmax,minvaluefeed,maxvaluefeed,
-    error_code){
+    errorCode){
   if (!ctx) {return;}
 
   // if (1 * maxvalue) == false: 3000. Else 1 * maxvalue
@@ -384,7 +384,7 @@ function draw_gauge(ctx,canvasid,x,y,width,height,position,maxvalue,units,decima
   }
     
   var dialtext;
-  if (error_code == "1")
+  if (errorCode == "1")
       {
         dialtext = "TO Error";
       }
@@ -542,12 +542,12 @@ function dial_define_tooltips(){
 function dial_draw(){
   $(".dial").each(function(index) {
     
-    var error_timeout = $(this).attr("timeout");
-        if (error_timeout == "" || error_timeout == undefined)            //Timeout parameter is empty
-          error_timeout = 0;
+    var errorTimeout = $(this).attr("timeout");
+        if (errorTimeout == "" || errorTimeout == undefined)            //Timeout parameter is empty
+          errorTimeout = 0;
 
 
-    var error_code = "0";
+    var errorCode = "0";
 
     var feedid = $(this).attr("feedid");
     var minvaluefeed = $(this).attr("minvaluefeed")||"0";
@@ -557,11 +557,11 @@ function dial_draw(){
     var val = (associd[feedid]["value"] * 1).toFixed(3);        
     var val_curve = curve_value(feedid,dialrate).toFixed(3);
 
-    if (error_timeout != 0)
+    if (errorTimeout != 0)
       {
-        if (((new Date()).getTime() / 1000 - offsetofTime - (associd[feedid]["time"] * 1)) > error_timeout) 
+        if (((new Date()).getTime() / 1000 - offsetofTime - (associd[feedid]["time"] * 1)) > errorTimeout) 
         {
-          error_code = "1";
+          errorCode = "1";
           val_curve = 0;        }
       }
     
@@ -606,7 +606,7 @@ function dial_draw(){
                  $(this).attr("displayminmax"),
                  minval_curve*scale,
                  maxval_curve*scale,
-                 error_code
+                 errorCode
                  );
     }
   });

--- a/widget/dial/dial_render.js
+++ b/widget/dial/dial_render.js
@@ -98,7 +98,7 @@ function dial_widgetlist(){
   addOption(widgets["dial"], "displayminmax", "dropbox", _Tr("Min / Max ?"),  _Tr("Display Min. and Max. ?"),                                               displayminmaxDropBoxOptions);
   addOption(widgets["dial"], "minvaluefeed",  "feedid",  _Tr("Min. feed"),    _Tr("The feed for the minimum value"),                                        []);
   addOption(widgets["dial"], "maxvaluefeed",  "feedid",  _Tr("Max. feed"),    _Tr("The feed for the maximum value"),                                        []);
-  addOption(widgets["dial"], "timeout",       "value",   _Tr("Timeout"),       _Tr("Timeout without feed update in seconds (0 is never, empty defaults to 60)"),                                           []);
+  addOption(widgets["dial"], "timeout",       "value",   _Tr("Timeout"),       _Tr("Timeout without feed update in seconds (empty is never)"),                                           []);
 
   return widgets;
 }

--- a/widget/dial/dial_render.js
+++ b/widget/dial/dial_render.js
@@ -543,8 +543,9 @@ function dial_draw(){
   $(".dial").each(function(index) {
     
     var errorTimeout = $(this).attr("timeout");
-        if (errorTimeout == "" || errorTimeout == undefined)            //Timeout parameter is empty
+        if (errorTimeout === "" || errorTimeout === undefined){            //Timeout parameter is empty
           errorTimeout = 0;
+        }
 
 
     var errorCode = "0";
@@ -557,7 +558,7 @@ function dial_draw(){
     var val = (associd[feedid]["value"] * 1).toFixed(3);        
     var val_curve = curve_value(feedid,dialrate).toFixed(3);
 
-    if (errorTimeout != 0)
+    if (errorTimeout !== 0)
       {
         if (((new Date()).getTime() / 1000 - offsetofTime - (associd[feedid]["time"] * 1)) > errorTimeout) 
         {

--- a/widget/dial/dial_widget.php
+++ b/widget/dial/dial_widget.php
@@ -1,0 +1,15 @@
+<?php
+/*
+  All Emoncms code is released under the GNU Affero General Public License.
+  See COPYRIGHT.txt and LICENSE.txt.
+    ---------------------------------------------------------------------
+    Part of the OpenEnergyMonitor project:
+    http://openenergymonitor.org
+    Widget initially created by Aymeric Thibaut
+ */
+ ?>
+<script type="application/javascript">
+  var requestTime = Date.now() /1000;
+  var offsetofTime = 0;
+  offsetofTime = Math.round(requestTime - <?php echo time(); ?>); // Offset in s from local to server time
+</script>

--- a/widget/feedtime/feedtime_render.js
+++ b/widget/feedtime/feedtime_render.js
@@ -10,7 +10,7 @@
     If you have any questions please get in touch, try the forums here:
     http://openenergymonitor.org/emon/forum
  */
- 
+
  function addOption(widget, optionKey, optionType, optionName, optionHint, optionData)
 {
   widget["options"    ].push(optionKey);
@@ -46,7 +46,6 @@ function feedtime_widgetlist()
         [5,    "5"],
         [6,    "6"]
     ];
-	
 
 	var fontoptions = [
 					[9, "Arial Black"],
@@ -60,18 +59,18 @@ function feedtime_widgetlist()
 					[1, "Georgia"],
 					[0, "Impact"]
 				];
-				
+
 	var fstyleoptions = [
 					[2, _Tr("Normal")],
 					[1, _Tr("Italic")],
 					[0, _Tr("Oblique")]
 				];
-				
+
 	var fweightoptions = [
 					[1, _Tr("Bold")],
 					[0, _Tr("Normal")]
 				];
-				
+
 	var sizeoptions = [
 					[14, "18"], // set size 18 to the top position to be the default value for creating new feedtime widgets otherwise size 40 would be always the default
 					[13, "40"],
@@ -93,7 +92,7 @@ function feedtime_widgetlist()
 	var unitEndOptions = [
 					[0, _Tr("Back")],
 					[1, _Tr("Front")]
-				];				
+				];
 
 	addOption(widgets["feedtime"], "feedid",     "feedid",  _Tr("Feed"),     _Tr("Feed value"),      []);
 	addOption(widgets["feedtime"], "colour",     "colour_picker",  _Tr("Colour"),     _Tr("Colour used for display"),      []);
@@ -124,7 +123,7 @@ function draw_feedtime(context,
 			if (!context){
 			return;
 			}
-			
+
 			context.save();
 			context.clearRect(0,0,width,height); // Clear old drawing
 			context.restore();
@@ -165,18 +164,18 @@ function draw_feedtime(context,
 			if (font === "7"){fontname = "sans-serif";}
 			if (font === "8"){fontname = "Arial Narrow";}
 			if (font === "9"){fontname = "Arial Black";}
-			
+
 			var fontstyle;
-			
+
 			if (fstyle === "0"){fontstyle = "oblique";}
 			if (fstyle === "1"){fontstyle = "italic";}
 			if (fstyle === "2"){fontstyle = "normal";}
-			
+
 			var fontweight;
 
 			if (fweight === "0"){fontweight = "normal";}
 			if (fweight === "1"){fontweight = "bold";}
-						
+
 			val = val.toFixed(0);
 
 			if (colour.indexOf("#") === -1){			// Fix missing "#" on colour if needed
@@ -199,15 +198,15 @@ function draw_feedtime(context,
 			}
 
 
-			
-			
+
+
 }
 
 function feedtime_draw()
 {
 	$(".feedtime").each(function(index)
 		{
-    
+
 			var font = $(this).attr("font");
 			var feedid = $(this).attr("feedid");
 			if (associd[feedid] === undefined) { console.log("Review config for feed id of " + $(this).attr("class")); return; }
@@ -220,11 +219,11 @@ function feedtime_draw()
 			var size = $(this).attr("size");
 			var units = $(this).attr("units");
 			var decimals = $(this).attr("decimals");
-			
+
 			if (decimals===undefined) {decimals = -1};
 
 			var unitend = $(this).attr("unitend");
-				
+
 			{
 				var id = "can-"+$(this).attr("id");
 

--- a/widget/feedtime/feedtime_render.js
+++ b/widget/feedtime/feedtime_render.js
@@ -101,7 +101,6 @@ function feedtime_widgetlist()
 	addOption(widgets["feedtime"], "fstyle",   "dropbox", _Tr("Font style"), _Tr("Font style used for display"),    fstyleoptions);
 	addOption(widgets["feedtime"], "fweight",   "dropbox", _Tr("Font weight"), _Tr("Font weight used for display"),    fweightoptions);
 	addOption(widgets["feedtime"], "units",      "value",   _Tr("Units"),    _Tr("Units to show"),   []);
-	addOption(widgets["feedtime"], "decimals",   "dropbox", _Tr("Decimals"), _Tr("Decimals to show"),    decimalsDropBoxOptions);
 	addOption(widgets["feedtime"], "size",   	"dropbox", _Tr("Size"), _Tr("Text size in px to use"),    sizeoptions);
 	addOption(widgets["feedtime"], "unitend",  "dropbox", _Tr("Unit position"), _Tr("Where should the unit be shown"), unitEndOptions);
 
@@ -119,7 +118,6 @@ function draw_feedtime(context,
 		val,
 		units,
 		colour,
-		decimals,
 		size,
 		unitend)
 		{
@@ -179,30 +177,7 @@ function draw_feedtime(context,
 			if (fweight === "0"){fontweight = "normal";}
 			if (fweight === "1"){fontweight = "bold";}
 						
-			if (decimals<0)
-				{
-
-					if (val>=100){
-						val = val.toFixed(0);
-						}
-					else if (val>=10){
-						val = val.toFixed(1);
-						}
-					else if (val<=-100){
-						val = val.toFixed(0);
-						}
-					else if (val<=-10){
-						val = val.toFixed(1);
-						}
-					else {
-						val = val.toFixed(2);
-						}
-				val = parseFloat(val);
-				}
-			else 
-				{
-					val = val.toFixed(decimals);
-				}
+			val = val.toFixed(0);
 
 			if (colour.indexOf("#") === -1){			// Fix missing "#" on colour if needed
 				colour = "#" + colour;	
@@ -264,7 +239,6 @@ function feedtime_draw()
 					val,
 					$(this).attr("units"),
 					$(this).attr("colour"),
-					$(this).attr("decimals"),
 					$(this).attr("size"),
 					$(this).attr("unitend"),
 					);

--- a/widget/feedtime/feedtime_render.js
+++ b/widget/feedtime/feedtime_render.js
@@ -20,11 +20,11 @@
   widget["optionsdata"].push(optionData);
 }
 
-function feedvalue_widgetlist()
+function feedtime_widgetlist()
 {
   var widgets =
   {
-    "feedvalue":
+    "feedtime":
     {
       "offsetx":-40,"offsety":-30,"width":120,"height":60,
       "menu":"Widgets",
@@ -73,7 +73,7 @@ function feedvalue_widgetlist()
 				];
 				
 	var sizeoptions = [
-					[14, "18"], // set size 18 to the top position to be the default value for creating new feedvalue widgets otherwise size 40 would be always the default
+					[14, "18"], // set size 18 to the top position to be the default value for creating new feedtime widgets otherwise size 40 would be always the default
 					[13, "40"],
 					[12, "36"],
 					[11, "32"],
@@ -95,21 +95,20 @@ function feedvalue_widgetlist()
 					[1, _Tr("Front")]
 				];				
 
-	addOption(widgets["feedvalue"], "feedid",     "feedid",  _Tr("Feed"),     _Tr("Feed value"),      []);
-	addOption(widgets["feedvalue"], "colour",     "colour_picker",  _Tr("Colour"),     _Tr("Colour used for display"),      []);
-	addOption(widgets["feedvalue"], "font",     "dropbox",  _Tr("Font"),     _Tr("Font used for display"),      fontoptions);
-	addOption(widgets["feedvalue"], "fstyle",   "dropbox", _Tr("Font style"), _Tr("Font style used for display"),    fstyleoptions);
-	addOption(widgets["feedvalue"], "fweight",   "dropbox", _Tr("Font weight"), _Tr("Font weight used for display"),    fweightoptions);
-	addOption(widgets["feedvalue"], "units",      "value",   _Tr("Units"),    _Tr("Units to show"),   []);
-	addOption(widgets["feedvalue"], "decimals",   "dropbox", _Tr("Decimals"), _Tr("Decimals to show"),    decimalsDropBoxOptions);
-	addOption(widgets["feedvalue"], "size",   	"dropbox", _Tr("Size"), _Tr("Text size in px to use"),    sizeoptions);
-	addOption(widgets["feedvalue"], "unitend",  "dropbox", _Tr("Unit position"), _Tr("Where should the unit be shown"), unitEndOptions);
-	addOption(widgets["feedvalue"], "timeout",      "value",   _Tr("Timeout"),    _Tr("Timeout without feed update (0 is never, empty is default"),   []);
+	addOption(widgets["feedtime"], "feedid",     "feedid",  _Tr("Feed"),     _Tr("Feed value"),      []);
+	addOption(widgets["feedtime"], "colour",     "colour_picker",  _Tr("Colour"),     _Tr("Colour used for display"),      []);
+	addOption(widgets["feedtime"], "font",     "dropbox",  _Tr("Font"),     _Tr("Font used for display"),      fontoptions);
+	addOption(widgets["feedtime"], "fstyle",   "dropbox", _Tr("Font style"), _Tr("Font style used for display"),    fstyleoptions);
+	addOption(widgets["feedtime"], "fweight",   "dropbox", _Tr("Font weight"), _Tr("Font weight used for display"),    fweightoptions);
+	addOption(widgets["feedtime"], "units",      "value",   _Tr("Units"),    _Tr("Units to show"),   []);
+	addOption(widgets["feedtime"], "decimals",   "dropbox", _Tr("Decimals"), _Tr("Decimals to show"),    decimalsDropBoxOptions);
+	addOption(widgets["feedtime"], "size",   	"dropbox", _Tr("Size"), _Tr("Text size in px to use"),    sizeoptions);
+	addOption(widgets["feedtime"], "unitend",  "dropbox", _Tr("Unit position"), _Tr("Where should the unit be shown"), unitEndOptions);
 
 	return widgets;
 }
 
-function draw_feedvalue(context,
+function draw_feedtime(context,
 		x_pos,				// these x and y coords seem unused?
 		y_pos,
 		font,
@@ -122,8 +121,7 @@ function draw_feedvalue(context,
 		colour,
 		decimals,
 		size,
-		unitend,
-		error_code)
+		unitend)
 		{
 			if (!context){
 			return;
@@ -215,53 +213,34 @@ function draw_feedvalue(context,
 				context.font = (fontstyle+ " "+ fontweight+ " "+ fontsize+"px "+ fontname);
 				}
 
-			if (error_code == "1")
+			if (unitend ==="0")
 			{
-				context.fillText("TO Error", width/2 , height/2);
+			context.fillText(val+units, width/2 , height/2);
 			}
 
-			else
+			if (unitend ==="1")
 			{
-				if (unitend ==="0")
-				{
-				context.fillText(val+units, width/2 , height/2);
-				}
-	
-				if (unitend ==="1")
-				{
-				context.fillText(units+val, width/2 , height/2);
-				}
+			context.fillText(units+val, width/2 , height/2);
 			}
+
 
 			
 			
 }
 
-function feedvalue_draw()
+function feedtime_draw()
 {
-	$(".feedvalue").each(function(index)
+	$(".feedtime").each(function(index)
 		{
     
-			var error_timeout = $(this).attr("timeout");
-	        if (error_timeout == "" || error_timeout == undefined)            //Timeout parameter is empty
-	          error_timeout = 60;
-
 			var font = $(this).attr("font");
 			var feedid = $(this).attr("feedid");
 			if (associd[feedid] === undefined) { console.log("Review config for feed id of " + $(this).attr("class")); return; }
-			var val = associd[feedid]["value"] * 1;
+
+			var val = ((new Date()).getTime() / 1000  - offsetofTime - (associd[feedid]["time"] * 1));
 
 			if (val===undefined) {val = 0;}
 			if (isNaN(val))  {val = 0;}
-
-			var error_code = "0";
-			if (error_timeout != 0)
-			{
-				if (((new Date()).getTime() / 1000 - offsetofTime - (associd[feedid]["time"] * 1)) > error_timeout) 
-				{
-					error_code = "1";
-				}
-			}
 
 			var size = $(this).attr("size");
 			var units = $(this).attr("units");
@@ -274,7 +253,7 @@ function feedvalue_draw()
 			{
 				var id = "can-"+$(this).attr("id");
 
-				draw_feedvalue(widgetcanvas[id],
+				draw_feedtime(widgetcanvas[id],
 					0,
 					0,
 					$(this).attr("font"),
@@ -288,22 +267,21 @@ function feedvalue_draw()
 					$(this).attr("decimals"),
 					$(this).attr("size"),
 					$(this).attr("unitend"),
-					error_code
 					);
 			}
 		});
 }
 
-function feedvalue_init()
+function feedtime_init()
 {
-	setup_widget_canvas("feedvalue");
+	setup_widget_canvas("feedtime");
 }
-function feedvalue_slowupdate()
+function feedtime_slowupdate()
 	{
-		feedvalue_draw();
+		feedtime_draw();
 	}
 
-function feedvalue_fastupdate()
+function feedtime_fastupdate()
 	{
-		feedvalue_draw();
+		feedtime_draw();
 	}

--- a/widget/feedtime/feedtime_widget.php
+++ b/widget/feedtime/feedtime_widget.php
@@ -1,0 +1,15 @@
+<?php
+/*
+  All Emoncms code is released under the GNU Affero General Public License.
+  See COPYRIGHT.txt and LICENSE.txt.
+    ---------------------------------------------------------------------
+    Part of the OpenEnergyMonitor project:
+    http://openenergymonitor.org
+    Widget initially created by Aymeric Thibaut
+ */
+ ?>
+<script type="application/javascript">
+  var requestTime = Date.now() /1000;
+  var offsetofTime = 0;
+  offsetofTime = Math.round(requestTime - <?php echo time(); ?>); // Offset in s from local to server time
+</script>

--- a/widget/feedvalue/feedvalue_render.js
+++ b/widget/feedvalue/feedvalue_render.js
@@ -215,7 +215,7 @@ function draw_feedvalue(context,
 				context.font = (fontstyle+ " "+ fontweight+ " "+ fontsize+"px "+ fontname);
 				}
 
-			if (errorCode == "1")
+			if (errorCode === "1")
 			{
 				context.fillText("TO Error", width/2 , height/2);
 			}
@@ -243,8 +243,9 @@ function feedvalue_draw()
 		{
     
 			var errorTimeout = $(this).attr("timeout");
-	        if (errorTimeout == "" || errorTimeout == undefined)            //Timeout parameter is empty
-	          errorTimeout = 0;
+			if (errorTimeout === "" || errorTimeout === undefined){           //Timeout parameter is empty
+				errorTimeout = 0;
+	        }
 
 			var font = $(this).attr("font");
 			var feedid = $(this).attr("feedid");
@@ -255,7 +256,7 @@ function feedvalue_draw()
 			if (isNaN(val))  {val = 0;}
 
 			var errorCode = "0";
-			if (errorTimeout != 0)
+			if (errorTimeout !== 0)
 			{
 				if (((new Date()).getTime() / 1000 - offsetofTime - (associd[feedid]["time"] * 1)) > errorTimeout) 
 				{

--- a/widget/feedvalue/feedvalue_render.js
+++ b/widget/feedvalue/feedvalue_render.js
@@ -244,7 +244,7 @@ function feedvalue_draw()
     
 			var error_timeout = $(this).attr("timeout");
 	        if (error_timeout == "" || error_timeout == undefined)            //Timeout parameter is empty
-	          error_timeout = 60;
+	          error_timeout = 0;
 
 			var font = $(this).attr("font");
 			var feedid = $(this).attr("feedid");

--- a/widget/feedvalue/feedvalue_render.js
+++ b/widget/feedvalue/feedvalue_render.js
@@ -104,7 +104,7 @@ function feedvalue_widgetlist()
 	addOption(widgets["feedvalue"], "decimals",   "dropbox", _Tr("Decimals"), _Tr("Decimals to show"),    decimalsDropBoxOptions);
 	addOption(widgets["feedvalue"], "size",   	"dropbox", _Tr("Size"), _Tr("Text size in px to use"),    sizeoptions);
 	addOption(widgets["feedvalue"], "unitend",  "dropbox", _Tr("Unit position"), _Tr("Where should the unit be shown"), unitEndOptions);
-	addOption(widgets["feedvalue"], "timeout",      "value",   _Tr("Timeout"),    _Tr("Timeout without feed update (0 is never, empty is default"),   []);
+	addOption(widgets["feedvalue"], "timeout",      "value",   _Tr("Timeout"),    _Tr("Timeout without feed update in seconds (0 is never, empty defaults to 60)"),   []);
 
 	return widgets;
 }

--- a/widget/feedvalue/feedvalue_render.js
+++ b/widget/feedvalue/feedvalue_render.js
@@ -104,7 +104,7 @@ function feedvalue_widgetlist()
 	addOption(widgets["feedvalue"], "decimals",   "dropbox", _Tr("Decimals"), _Tr("Decimals to show"),    decimalsDropBoxOptions);
 	addOption(widgets["feedvalue"], "size",   	"dropbox", _Tr("Size"), _Tr("Text size in px to use"),    sizeoptions);
 	addOption(widgets["feedvalue"], "unitend",  "dropbox", _Tr("Unit position"), _Tr("Where should the unit be shown"), unitEndOptions);
-	addOption(widgets["feedvalue"], "timeout",      "value",   _Tr("Timeout"),    _Tr("Timeout without feed update in seconds (0 is never, empty defaults to 60)"),   []);
+	addOption(widgets["feedvalue"], "timeout",      "value",   _Tr("Timeout"),    _Tr("Timeout without feed update in seconds (empty is never)"),   []);
 
 	return widgets;
 }

--- a/widget/feedvalue/feedvalue_render.js
+++ b/widget/feedvalue/feedvalue_render.js
@@ -123,7 +123,7 @@ function draw_feedvalue(context,
 		decimals,
 		size,
 		unitend,
-		error_code)
+		errorCode)
 		{
 			if (!context){
 			return;
@@ -215,7 +215,7 @@ function draw_feedvalue(context,
 				context.font = (fontstyle+ " "+ fontweight+ " "+ fontsize+"px "+ fontname);
 				}
 
-			if (error_code == "1")
+			if (errorCode == "1")
 			{
 				context.fillText("TO Error", width/2 , height/2);
 			}
@@ -242,9 +242,9 @@ function feedvalue_draw()
 	$(".feedvalue").each(function(index)
 		{
     
-			var error_timeout = $(this).attr("timeout");
-	        if (error_timeout == "" || error_timeout == undefined)            //Timeout parameter is empty
-	          error_timeout = 0;
+			var errorTimeout = $(this).attr("timeout");
+	        if (errorTimeout == "" || errorTimeout == undefined)            //Timeout parameter is empty
+	          errorTimeout = 0;
 
 			var font = $(this).attr("font");
 			var feedid = $(this).attr("feedid");
@@ -254,12 +254,12 @@ function feedvalue_draw()
 			if (val===undefined) {val = 0;}
 			if (isNaN(val))  {val = 0;}
 
-			var error_code = "0";
-			if (error_timeout != 0)
+			var errorCode = "0";
+			if (errorTimeout != 0)
 			{
-				if (((new Date()).getTime() / 1000 - offsetofTime - (associd[feedid]["time"] * 1)) > error_timeout) 
+				if (((new Date()).getTime() / 1000 - offsetofTime - (associd[feedid]["time"] * 1)) > errorTimeout) 
 				{
-					error_code = "1";
+					errorCode = "1";
 				}
 			}
 
@@ -288,7 +288,7 @@ function feedvalue_draw()
 					$(this).attr("decimals"),
 					$(this).attr("size"),
 					$(this).attr("unitend"),
-					error_code
+					errorCode
 					);
 			}
 		});

--- a/widget/feedvalue/feedvalue_widget.php
+++ b/widget/feedvalue/feedvalue_widget.php
@@ -1,0 +1,15 @@
+<?php
+/*
+  All Emoncms code is released under the GNU Affero General Public License.
+  See COPYRIGHT.txt and LICENSE.txt.
+    ---------------------------------------------------------------------
+    Part of the OpenEnergyMonitor project:
+    http://openenergymonitor.org
+    Widget initially created by Aymeric Thibaut
+ */
+ ?>
+<script type="application/javascript">
+  var requestTime = Date.now() /1000;
+  var offsetofTime = 0;
+  offsetofTime = Math.round(requestTime - <?php echo time(); ?>); // Offset in s from local to server time
+</script>


### PR DESCRIPTION
Hi all, this is my first pull request to th EmonCMS project.

For I time, I had the problem of not noticing when a device stopped sending data, because the widgets continued to display the feed value, even if it wasn't updated.

The 3 widgets I use commonly are FeedValue, Dial and Bar, so I edited only these.

I have added a new parameter in the config options of each widget, called timeout. After the seconds specified in timeout without feed update, the widget shows "TO Error" in the numeric display and the Dial or the Bar goes to 0.

If 0 is specified in the timeout value, it never timeouts. If it is left empty, it timeouts to 60 seconds. I added this last feature for not changing all the dashboards I have.

I also added a new widget called FeedTime, which shows how old is a feed in seconds.

Thanks :)
