### PR TITLE
fix ie11 error

### DIFF
--- a/widget/feedtime/feedtime_render.js
+++ b/widget/feedtime/feedtime_render.js
@@ -239,7 +239,7 @@ function feedtime_draw()
 					$(this).attr("units"),
 					$(this).attr("colour"),
 					$(this).attr("size"),
-					$(this).attr("unitend"),
+					$(this).attr("unitend")
 					);
 			}
 		});


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29287201/37226413-1e8c27aa-23da-11e8-8ddc-55479c368fdc.png)

Comma removed. Without this fix, widgets are not displayed in IE11 (works with firefox and Edge anyway)