### PR TITLE
enlarge space for tags - color picker improvement

### DIFF
--- a/Views/js/designer.js
+++ b/Views/js/designer.js
@@ -351,7 +351,7 @@ var designer = {
 
             options_html += '<div class="control-group"><div class="controls">';
             options_html += '<div class="input-prepend" style="margin-bottom: 0px;">';
-            options_html += '<span class="add-on" style="width:80px; text-align: right;">'+options_name[z]+'</span>';
+            options_html += '<span class="add-on" style="width:100px; text-align: right; font-size:12px;">'+options_name[z]+'</span>';
 
             // all feeds
 
@@ -431,13 +431,13 @@ var designer = {
         // Generic sizing options for all widgets (an hack so we dont add new options to all widgets)
         var selPixel = (designer.boxlist[selected_box]["styleUnitWidth"] == 0 ? "selected" : "");
         var selPercent = (designer.boxlist[selected_box]["styleUnitWidth"] == 1 ? "selected" : "");
-        options_html += '<div class="control-group"><div class="controls"><div style="margin-bottom: 0px;" class="input-prepend"><span style="width:80px; text-align: right;" class="add-on">'+_Tr("Width")+'</span>';
+        options_html += '<div class="control-group"><div class="controls"><div style="margin-bottom: 0px;" class="input-prepend"><span style="width:100px; text-align: right; font-size:12px;" class="add-on">'+_Tr("Width")+'</span>';
         options_html += '<select class="options" id="styleUnitWidth"><option value="0" '+selPixel+'>'+_Tr("Pixels")+'</option><option value="1" '+selPercent+'>'+_Tr("Percentage")+'</option></select>';
         options_html += '</div><span class="help-inline"><small class="muted">'+_Tr("Choose width unit")+'</small></span></div></div>';
 
         var selPixel = (designer.boxlist[selected_box]["styleUnitHeight"] == 0 ? "selected" : "");
         var selPercent = (designer.boxlist[selected_box]["styleUnitHeight"] == 1 ? "selected" : "");
-        options_html += '<div class="control-group"><div class="controls"><div style="margin-bottom: 0px;" class="input-prepend"><span style="width:80px; text-align: right;" class="add-on">'+_Tr("Height")+'</span>';
+        options_html += '<div class="control-group"><div class="controls"><div style="margin-bottom: 0px;" class="input-prepend"><span style="width:100px; text-align: right; font-size:12px;" class="add-on">'+_Tr("Height")+'</span>';
         options_html += '<select class="options" id="styleUnitHeight"><option value="0" '+selPixel+'>'+_Tr("Pixels")+'</option><option value="1" '+selPercent+'>'+_Tr("Percentage")+'</option></select>';
         options_html += '</div><span class="help-inline"><small class="muted">'+_Tr("Choose height unit")+'</small></span></div></div>';
 
@@ -445,6 +445,11 @@ var designer = {
 
         // Fill the modal configuration window with options
         $("#widget_options_body").html(options_html);
+
+        // Change the size of the text for items with class options - size initially set by bootstrap
+        // also add height of 30 px for color inputs
+        $('input, select, textarea').css('font-size','12px');
+        $("input[type='color']").css('height','30px');
     },
     
     "select_feed": function (id, feedlist, type, currentval){

--- a/Views/js/designer.js
+++ b/Views/js/designer.js
@@ -447,9 +447,9 @@ var designer = {
         $("#widget_options_body").html(options_html);
 
         // Change the size of the text for items with class options - size initially set by bootstrap
-        // also add height of 30 px for color inputs
+        // also add height of 30 px for color inputs for Firefox
         $('input, select, textarea').css('font-size','12px');
-        $("input[type='color']").css('height','30px');
+        if (navigator.userAgent.search("Firefox") >= 0) {$("input[type='color']").css({'height':'30px', 'width':'220px'});};
     },
     
     "select_feed": function (id, feedlist, type, currentval){


### PR DESCRIPTION
Before : 
![image](https://user-images.githubusercontent.com/29287201/41508222-7cd47136-7241-11e8-970a-aeb61ed2c87d.png)
text truncated
![image](https://user-images.githubusercontent.com/29287201/41508229-934aa9f8-7241-11e8-8f03-8e896ae3bc82.png)
issue with color picker on FireFox 60.0.2
After : 
![image](https://user-images.githubusercontent.com/29287201/41508245-d6723f48-7241-11e8-91af-f926d328a61d.png)
text no longer truncated : size increased for tags and font size decreased
![image](https://user-images.githubusercontent.com/29287201/41508254-1764491a-7242-11e8-8194-723bacb0b312.png)
color picker now correctly displayed on Firefox