### PR TITLE
added hidden title to allow bookmarks to name the link

### DIFF
--- a/Views/dashboard_view.php
+++ b/Views/dashboard_view.php
@@ -36,7 +36,7 @@ if ($session['write']) $dashboard_editor_icon ='<a href="'.$path.'dashboard/edit
   <script type="text/javascript" src="<?php echo $path; ?>Modules/feed/feed.js?ver=<?php echo $js_css_version; ?>"></script>
 
   <?php require_once "Modules/dashboard/Views/loadwidgets.php"; ?>
-
+<h2 class="d-none"><?php echo $dashboard['name'] ?></h2>
  <div id="editicon" class="hidden-phone">
 	<div id="innerbutton" style="cursor: default">
 		<?php echo $dashboard_editor_icon; ?>


### PR DESCRIPTION
To enable the bookmarks feature to name the dashboard correctly it requires a hidden page title. this pull request does that work