### PR TITLE
used dashboard id to build edit and view urls

### DIFF
--- a/dashboard_menu.php
+++ b/dashboard_menu.php
@@ -32,7 +32,7 @@
         $menu['sidebar']['dashboard'][] = array(
             'title' => $dash['desc'],
             'text' => $dash['name'],
-            'path' => $dash['path'],
+            'path' => str_replace('dashboard/view&id','dashboard/view?id',$dash['path']),
             'active' => array(
                 sprintf('dashboard/edit?id=%s',$id),
                 sprintf('dashboard/view?id=%s',$id)
@@ -44,6 +44,7 @@
             )
         );
     }
+    var_dump($menu);exit();
 
     $menu['sidebar']['dashboard'][] = array(
         'text'=> dgettext("dashboard_messages","All Dashboards"),

--- a/dashboard_menu.php
+++ b/dashboard_menu.php
@@ -44,7 +44,6 @@
             )
         );
     }
-    var_dump($menu);exit();
 
     $menu['sidebar']['dashboard'][] = array(
         'text'=> dgettext("dashboard_messages","All Dashboards"),

--- a/dashboard_menu.php
+++ b/dashboard_menu.php
@@ -26,14 +26,17 @@
     $listmenu = $dashboard->build_menu_array('view');
 
     foreach ($listmenu as $dash) {
-        preg_match('#dashboard\/view\&id=(\d+)#', $dash['path'], $matches);
-        $id = !empty($matches[1]) ? (int) $matches[1]: '';
+        $id = $dash['id'];
+
         $icon = !empty($default['id']) && $default['id'] === $id ? 'star': '';
         $menu['sidebar']['dashboard'][] = array(
             'title' => $dash['desc'],
             'text' => $dash['name'],
-            'path' => str_replace('dashboard/view&id','dashboard/view?id',$dash['path']),
-            'active' => str_replace('dashboard/view&id','dashboard/edit?id',$dash['path']),
+            'path' => $dash['path'],
+            'active' => array(
+                sprintf('dashboard/edit?id=%s',$id),
+                sprintf('dashboard/view?id=%s',$id)
+            ),
             'order' => $dash['order'],
             'icon' => $icon,
             'data' => array(

--- a/dashboard_model.php
+++ b/dashboard_model.php
@@ -237,7 +237,14 @@ class Dashboard
             }
 
             // Build the menu item
-            $menu[] = array('name' => $dashboard['name'], 'desc'=> $desc, 'published'=> $dashboard['published'], 'path' => $dashpath.$aliasurl, 'order' => "-1".$dashboard['name']);
+            $menu[] = array(
+                'id' => $dashboard['id'],
+                'name' => $dashboard['name'],
+                'desc'=> $desc,
+                'published'=> $dashboard['published'],
+                'path' => $dashpath.$aliasurl,
+                'order' => "-1".$dashboard['name']
+            );
         }
         return $menu;
     }


### PR DESCRIPTION
modified model to supply dashboard id

fix #214 

the menu item now responds to any one of these urls:
- dashboard/view?id=[dashboard id]
- dashboard/edit?id=[dashboard id]
- dashboard/view/[dashboard alias]
