### PR TITLE
Add blocks feature

### DIFF
--- a/widget/battery/battery_render.js
+++ b/widget/battery/battery_render.js
@@ -86,6 +86,7 @@ function battery_widgetlist(){
   addOption(widgets["battery"], "scale",                 "value",         _Tr("Scale"),           _Tr("Value is multiplied by scale before display"),                           []);
   addOption(widgets["battery"], "units",                 "dropbox_other", _Tr("Units"),           _Tr("Units to show"),                                                         _SI);
   addOption(widgets["battery"], "unitend",               "dropbox",       _Tr("Unit position"),   _Tr("Where should the unit be shown"),                                        unitEndOptions);
+  addOption(widgets["battery"], "number_of_blocks",      "value",         _Tr("Number of blocks"),_Tr("Number of blocks to display"),                                           []);
   addOption(widgets["battery"], "decimals",              "dropbox",       _Tr("Decimals"),        _Tr("Decimals to show"),                                                      decimalsDropBoxOptions);
   addOption(widgets["battery"], "offset",                "value",         _Tr("Offset"),          _Tr("Static offset. Subtracted from value before computing"),                 []);
   addOption(widgets["battery"], "colour",                "colour_picker", _Tr("Colour label"),    _Tr("Color of the label"),                                                    []);
@@ -153,7 +154,7 @@ function battery_draw(){
       var cap_width = battery_width/3;
       var line_width = 2;
       var margin = 1;
-      var number_of_blocks = 5;
+      var number_of_blocks = Math.round(1*$(this).attr("number_of_blocks")) || 5;
 
       var fontname;
       if (font === "0"){fontname = "Impact";}


### PR DESCRIPTION
Add the ability to define the number of blocks within the battery : 
![image](https://user-images.githubusercontent.com/29287201/77960366-7898be80-72d8-11ea-8335-f30b9b9d5d54.png)
![image](https://user-images.githubusercontent.com/29287201/77960393-83ebea00-72d8-11ea-893c-d1baa8ec4ef4.png)
For backward compatibility : default value is 5